### PR TITLE
Refactor: Remove server-side AI provider check for ctx.sample

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,17 +187,9 @@ async def get_ai_guidance(
         Format the response clearly with actionable advice.
         """
 
-        settings = ctx.request_context.lifespan_context["settings"]
-        if not settings.has_ai_provider:
-            logger.warning("get_ai_guidance: No AI provider configured.")
-            return (
-                "⚠️ AI provider not configured. "
-                "This feature requires an AI provider (e.g., Anthropic, OpenAI) "
-                "to be configured in the server's environment settings. "
-                "Please contact the server administrator."
-            )
-
-        # Use context.sample for AI-powered guidance
+        # Use context.sample for AI-powered guidance.
+        # The MCP client (e.g., Claude Desktop) is responsible for having an AI provider configured.
+        # The server itself does not need API keys in its own environment for ctx.sample() to work.
         guidance = await ctx.sample(guidance_prompt)
         return f"🧠 AI Guidance - {topic.title()}:\n\n{guidance}"
 


### PR DESCRIPTION
Removed the `settings.has_ai_provider` check within the `get_ai_guidance` tool in `main.py`.

The `ctx.sample()` primitive relies on the MCP client (e.g., Claude Desktop) to have an AI provider configured and to perform the actual LLM call. The server does not need its own API keys for `ctx.sample()` to function. The existing try-except block around `ctx.sample()` will handle failures if the client is unable to process the request.

This change avoids potential confusion about where AI provider configuration is necessary when using `ctx.sample()`.