### PR TITLE
Fix: Update internal refs to renamed Settings fields

### DIFF
--- a/src/mcp_creator/core/server_generator.py
+++ b/src/mcp_creator/core/server_generator.py
@@ -123,7 +123,7 @@ Use `list_templates` to see all options."""
         if spec.output_dir:
             base_dir = Path(spec.output_dir)
         else:
-            base_dir = self.settings.output_dir
+            base_dir = self.settings.default_output_dir # Updated to default_output_dir
 
         server_dir = base_dir / spec.name
         server_dir.mkdir(parents=True, exist_ok=True)

--- a/src/mcp_creator/core/template_manager.py
+++ b/src/mcp_creator/core/template_manager.py
@@ -41,7 +41,7 @@ class TemplateManager:
         self.settings = settings
         self.templates: dict[str, Template] = {}
         self.jinja_env = Environment(
-            loader=FileSystemLoader(str(settings.template_dir)),
+            loader=FileSystemLoader(str(settings.template_cache_dir)), # Updated to template_cache_dir
             autoescape=select_autoescape(["html", "xml"]),
             trim_blocks=True,
             lstrip_blocks=True,
@@ -90,13 +90,15 @@ class TemplateManager:
 
     async def _discover_templates(self) -> None:
         """Discover and load template metadata."""
-        template_dir = self.settings.template_dir / "languages"
+        # Use the updated settings field name for the base template directory
+        base_template_dir = self.settings.template_cache_dir
+        template_languages_dir = base_template_dir / "languages"
 
-        if not template_dir.exists():
-            logger.warning(f"Template directory not found: {template_dir}")
+        if not template_languages_dir.exists():
+            logger.warning(f"Template languages directory not found: {template_languages_dir}")
             return
 
-        for lang_dir in template_dir.iterdir():
+        for lang_dir in template_languages_dir.iterdir(): # Updated variable name
             if not lang_dir.is_dir():
                 continue
 

--- a/src/mcp_creator/workflows/workflow_engine.py
+++ b/src/mcp_creator/workflows/workflow_engine.py
@@ -182,12 +182,12 @@ class WorkflowEngine:
 
     async def _load_workflows(self) -> None:
         """Load workflows from disk."""
-        workflow_dir = self.settings.workflow_dir
+        load_dir = self.settings.workflow_save_dir # Updated to workflow_save_dir
 
-        if not workflow_dir.exists():
+        if not load_dir.exists():
             return
 
-        for workflow_file in workflow_dir.glob("*.json"):
+        for workflow_file in load_dir.glob("*.json"):
             try:
                 async with aiofiles.open(workflow_file) as f:
                     content = await f.read()
@@ -202,7 +202,8 @@ class WorkflowEngine:
 
     async def _persist_workflow(self, workflow_id: str, workflow: Workflow) -> None:
         """Save workflow to disk."""
-        workflow_file = self.settings.workflow_dir / f"{workflow_id}.json"
+        save_dir = self.settings.workflow_save_dir # Updated to workflow_save_dir
+        workflow_file = save_dir / f"{workflow_id}.json"
 
         async with aiofiles.open(workflow_file, "w") as f:
             content = json.dumps(workflow.to_dict(), indent=2)


### PR DESCRIPTION
Corrected internal references to fields in the `Settings` object that were renamed in a previous commit. This resolves `AttributeError` issues at startup.

Changes:
- In `TemplateManager`: updated `settings.template_dir` to `settings.template_cache_dir`.
- In `WorkflowEngine`: updated `settings.workflow_dir` to `settings.workflow_save_dir`.
- In `ServerGenerator`: updated `settings.output_dir` to `settings.default_output_dir`.